### PR TITLE
update broken dep; add .dockerignore

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build-test:
     docker:
-      - image: circleci/golang:1.12
+      - image: circleci/golang:1.13rc2
     steps:
       - setup_remote_docker:
           docker_layer_caching: true

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+node_modules
+vendor
+/dist
+/tmp
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build GoChain in a stock Go builder container
-FROM golang:alpine as backend_builder
+FROM golang:1.13rc2-alpine as backend_builder
 RUN apk --no-cache add build-base git bzr mercurial gcc linux-headers g++ make
 ENV D=/explorer
 WORKDIR $D
@@ -11,7 +11,7 @@ ADD . $D
 # build
 RUN cd $D && make backend && mkdir -p /tmp/gochain && cp $D/server/server /tmp/gochain/ && cp $D/grabber/grabber /tmp/gochain/
 
-FROM node:10-alpine  as frontend_builder
+FROM node:10-alpine as frontend_builder
 WORKDIR /explorer
 RUN apk add --no-cache make git gcc g++ python
 ADD . /explorer

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"flag"
 	"log"
+	"os"
 	"testing"
 
 	"github.com/gochain-io/explorer/client"
@@ -23,7 +24,7 @@ var (
 	c        *client.Client
 )
 
-func init() {
+func TestMain(m *testing.M) {
 	flag.Parse()
 	if *url != "" {
 		log.Println("Using custom url:", *url)
@@ -46,6 +47,8 @@ func init() {
 			testAddr = mainnetTestAddr
 		}
 	}
+
+	os.Exit(m.Run())
 }
 
 func TestClient_TotalSupplyWei(t *testing.T) {

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -15,18 +15,13 @@ trap cleanup_containers SIGINT EXIT SIGHUP
 docker run --name test_mongo -d -p 8545:8545 -p 8080:8080 -p 27017:27017 mongo
 varA=`docker ps --no-trunc -q | cut -c 1-12`
 # build
+docker build --target backend_builder -t gochain/explorer-back-build .
 docker build -t gochain/explorer:test_ci .
 # launch required containers
 docker run --name test_explorer_grabber -d --network="container:$varA" gochain/explorer:test_ci grabber -u https://testnet-rpc.gochain.io -s 10
 docker run --name test_explorer_server -d --network="container:$varA" gochain/explorer:test_ci server -d /explorer/ -u https://testnet-rpc.gochain.io
 # this will run both integration and unit tests, integration test will require mongo running that why it should be running in the same network with mongo
-docker run --name test_explorer_go_integration -d -w /explorer --network="container:$varA" golang:alpine /bin/sh -c "while true; do sleep 15 ; done"
-# looks like due to some limitations it's not possilbe to just map the current directory to a container, that why you have to use docker cp
-docker cp . test_explorer_go_integration:/explorer
-# Installing build deps for tests
-docker exec test_explorer_go_integration apk add git gcc linux-headers g++ make
-# run the tests inside running container
-docker exec test_explorer_go_integration go test -tags=integration ./...
+docker run --name test_explorer_go_integration --network="container:$varA" gochain/explorer-back-build go test -tags=integration ./...
 sleep 5 # let's wait until server start
 # docker exec test_explorer npm test
 echo "Docker logs for grabber"


### PR DESCRIPTION
Fixes the build by updating to newer go, and simplifies `Dockerfile` and `run_tests.sh`.