### PR TITLE
use ctx with signal interrupt

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/go-chi/cors v1.0.0
 	github.com/go-ini/ini v1.42.0 // indirect
 	github.com/go-stack/stack v1.8.0 // indirect
+	github.com/gochain-io/gochain v2.2.26+incompatible
 	github.com/gochain-io/gochain/v3 v3.1.3
 	github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db // indirect
 	github.com/google/uuid v1.0.0 // indirect
@@ -38,4 +39,5 @@ require (
 	golang.org/x/sync v0.0.0-20181108010431-42b317875d0f // indirect
 	gopkg.in/ini.v1 v1.42.0 // indirect
 	gopkg.in/mgo.v2 v2.0.0-20180705113604-9856a29383ce
+	gopkg.in/urfave/cli.v1 v1.20.0
 )

--- a/go.sum
+++ b/go.sum
@@ -29,6 +29,7 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/docker/docker v1.13.1/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/edsrzf/mmap-go v0.0.0-20170320065105-0bce6a688712 h1:aaQcKT9WumO6JEJcRyTqFVq4XUZiUcKR2/GI31TOcz8=
 github.com/edsrzf/mmap-go v0.0.0-20170320065105-0bce6a688712/go.mod h1:YO35OhQPt3KJa3ryjFM5Bs14WD66h8eGKpfaBNrHW5M=
+github.com/elastic/gosigar v0.0.0-20180330100440-37f05ff46ffa h1:o8OuEkracbk3qH6GvlI6XpEN1HTSxkzOG42xZpfDv/s=
 github.com/elastic/gosigar v0.0.0-20180330100440-37f05ff46ffa/go.mod h1:cdorVVzy1fhmEqmtgqkoE3bYtCfSCkVyjTyCIo22xvs=
 github.com/fatih/color v1.6.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fjl/memsize v0.0.0-20180929194037-2a09253e352a h1:1znxn4+q2MrEdTk1eCk6KIV3muTYVclBIB6CTVR/zBc=
@@ -48,6 +49,8 @@ github.com/go-ole/go-ole v1.2.1/go.mod h1:7FAglXiTm7HKlQRDeOQ6ZNUHidzCWXuZWq/1dT
 github.com/go-stack/stack v1.7.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-stack/stack v1.8.0 h1:5SgMzNM5HxrEjV0ww2lTmX6E2Izsfxas4+YHWRs3Lsk=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
+github.com/gochain-io/gochain v2.2.26+incompatible h1:rmVGz8wCSyP7R869iCe2s1+VmpgFNP/pA5VWT+KKxzY=
+github.com/gochain-io/gochain v2.2.26+incompatible/go.mod h1:Ka3R7w3BBA2ZQnr7PkBTX8ktVW1hidoo8QutcctSANI=
 github.com/gochain-io/gochain/v3 v3.1.3 h1:jIdZbcyyFt28DylncAw8pD+9IlLb3VWdIJ5sMuH1Qbo=
 github.com/gochain-io/gochain/v3 v3.1.3/go.mod h1:e+h1qGhr65M3MlO3kOnXRMXq6Btu8GJnOZWeCXauy9I=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
@@ -195,6 +198,7 @@ gopkg.in/mgo.v2 v2.0.0-20180705113604-9856a29383ce h1:xcEWjVhvbDy+nHP67nPDDpbYrY
 gopkg.in/mgo.v2 v2.0.0-20180705113604-9856a29383ce/go.mod h1:yeKp02qBN3iKW1OzL3MGk2IdtZzaj7SFntXj72NppTA=
 gopkg.in/natefinch/npipe.v2 v2.0.0-20160621034901-c1b8fa8bdcce h1:+JknDZhAj8YMt7GC73Ei8pv4MzjDUNPHgQWJdtMAaDU=
 gopkg.in/natefinch/npipe.v2 v2.0.0-20160621034901-c1b8fa8bdcce/go.mod h1:5AcXVHNjg+BDxry382+8OKon8SEWiKktQR07RKPsv1c=
+gopkg.in/olebedev/go-duktape.v3 v3.0.0-20180302121509-abf0ba0be5d5 h1:VWXVtmkY4YFVuF1FokZ0PUsuvtx3Di6z/m47daSP5f0=
 gopkg.in/olebedev/go-duktape.v3 v3.0.0-20180302121509-abf0ba0be5d5/go.mod h1:uAJfkITjFhyEEuUfm7bsmCZRbW5WRq8s9EY8HZ6hCns=
 gopkg.in/sourcemap.v1 v1.0.5/go.mod h1:2RlvNNSMglmRrcvhfuzp4hQHwOtjxlbjX7UPY/GXb78=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=

--- a/server/backend/backend_test.go
+++ b/server/backend/backend_test.go
@@ -3,34 +3,35 @@
 package backend
 
 import (
+	"context"
 	"math/big"
 	"testing"
 	"time"
 
 	"github.com/gochain-io/explorer/server/models"
-	"go.uber.org/zap"
-	"go.uber.org/zap/zaptest"
 
 	"github.com/gochain-io/gochain/v3/common"
 	"github.com/gochain-io/gochain/v3/core/types"
 	"github.com/gochain-io/gochain/v3/rlp"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
 )
 
 func getBackend(t *testing.T) *Backend {
-	b, err := NewBackend("127.0.0.1:27017", "https://rpc.gochain.io", "testdb", nil, nil, zaptest.NewLogger(t))
+	b, err := NewBackend(context.Background(), "127.0.0.1:27017", "https://rpc.gochain.io", "testdb", nil, nil, zaptest.NewLogger(t))
 	if err != nil {
 		t.Fatalf("failed to create backend: %v", err)
 	}
 	return b
 }
 
-func createImportBlock(testBackend *Backend) types.Block {
+func createImportBlock(ctx context.Context, testBackend *Backend) types.Block {
 	blockEnc := common.FromHex("0xf90425f90260a0ca12d831416f1fd29336c535ee814d228f638b10798b5cf437bef29415e63762a01dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d493479448c67d87cd7d716ec044dbe33a0152557bf86062c0c0b84105faed8a008cdb41757cfca7462e440f13f1369a9dc14aafbc1eca77575b6f4753d34458da828f3028fc075e3d6e7b944c3b6b8327dbbd702a1a3ee0c6f8663301a0df5891f347b7525b4369d81238f399a046fb94194e0785d42ba93446b1e27c19a013d863c4c708ff270b60de30faa63e49f073b5ac0e90cdcddb1b10c0736cc923a004deb4be6955e1a300123be48007597f67e4229f8ce70f4f10388de6fd3fa267b90100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000e8314be5c840822d32083014820845b634071a0322e312e33362f6c696e75782d616d6436342f676f312e31302e330000000000a00000000000000000000000000000000000000000000000000000000000000000880000000000000000f901bef86d80847735940082520894bf47332f391f995e0e050bc0778a49c61bdd8fdf8911efc99828edb2600080819ca08f2579f5372bfadca519dfa96b9a7e16689632b65a469c8f96262034d306e104a051692d3de03154e5506afe4616304e6e70bcd7ba7c367b59226045eacd21a8ddf86d01847735940082520894bf47332f391f995e0e050bc0778a49c61bdd8fdf894add3970f31b5f600080819ca0e95246628a5c110356c23a176a97d9dc8a62069b75ef59b090b9074a69eedb63a07882befc79d5e2a5214e33fcc7f2beb45d85551bc4c63588817af2cb83df00b1f86e09847735940082520894bf47332f391f995e0e050bc0778a49c61bdd8fdf8a0b69448bfc2ed424600080819ca08e0645ff002bb43239c22d64cab5dd799b2bb9c56f92d90eb50be7860d4aadd4a00bf2701bb7e1df17921c598954621c724c6a7c50cd1583e117c10708d3c1a537f86e05847735940082520894bf47332f391f995e0e050bc0778a49c61bdd8fdf8a05b7ac452dab97cb600080819ba00a0cacc5f5c556c2435f3e6e43635eda857f71e2f95d73c450ea01a481018011a02cb5ec486060a6f53fd5afdb4f87c57842b7600f3790d66a7bda90fdf0135e93c0")
 	var block types.Block
 	if err := rlp.DecodeBytes(blockEnc, &block); err != nil {
 		testBackend.Lgr.Fatal("decode error", zap.Error(err))
 	}
-	testBackend.ImportBlock(&block)
+	testBackend.ImportBlock(ctx, &block)
 	return block
 }
 
@@ -52,7 +53,7 @@ func TestImportAddress(t *testing.T) {
 	}
 	wrongAddressHash := "0x000"
 
-	address, err := testBackend.GetAddressByHash(wrongAddressHash)
+	address, err := testBackend.GetAddressByHash(context.Background(), wrongAddressHash)
 
 	if err == nil {
 		t.Errorf("Address was incorrect, expected error, got: %v, want: %s.", address, addrHash)
@@ -62,8 +63,8 @@ func TestImportAddress(t *testing.T) {
 func TestImportBlockTransaction(t *testing.T) {
 	testBackend := getBackend(t)
 	defer testBackend.mongo.cleanUp()
-	block := createImportBlock(testBackend)
-	blockFromDb := testBackend.GetBlockByNumber(block.Header().Number.Int64())
+	block := createImportBlock(context.Background(), testBackend)
+	blockFromDb := testBackend.GetBlockByNumber(context.Background(), block.Header().Number.Int64())
 
 	if block.Header().Number.Int64() != blockFromDb.Number || block.Header().Number.Int64() != 1359452 {
 		t.Errorf("Block number was incorrect, got: %d, want: %d.", block.Header().Number.Int64(), 1359452)
@@ -80,7 +81,7 @@ func TestImportBlockTransaction(t *testing.T) {
 func TestTransactions(t *testing.T) {
 	testBackend := getBackend(t)
 	defer testBackend.mongo.cleanUp()
-	block := createImportBlock(testBackend)
+	block := createImportBlock(context.Background(), testBackend)
 
 	transactionsFromDb := testBackend.GetBlockTransactionsByNumber(block.Header().Number.Int64(), 0, 100)
 
@@ -91,7 +92,7 @@ func TestTransactions(t *testing.T) {
 	if block.Transactions()[0].Hash().Hex() != transactionsFromDb[0].TxHash {
 		t.Errorf("Block transaction was incorrect, got: %s, want: %s.", block.Transactions()[0].Hash().Hex(), transactionsFromDb[0].TxHash)
 	}
-	transactionFromDB := testBackend.GetTransactionByHash(block.Transactions()[0].Hash().Hex())
+	transactionFromDB := testBackend.GetTransactionByHash(context.Background(), block.Transactions()[0].Hash().Hex())
 
 	if block.Transactions()[0].Hash().Hex() != transactionFromDB.TxHash {
 		t.Errorf("Block transaction was incorrect, got: %s, want: %s.", block.Transactions()[0].Hash().Hex(), transactionFromDB.TxHash)
@@ -116,7 +117,7 @@ func TestTransactions(t *testing.T) {
 func TestBlockByHash(t *testing.T) {
 	testBackend := getBackend(t)
 	defer testBackend.mongo.cleanUp()
-	block := createImportBlock(testBackend)
+	block := createImportBlock(context.Background(), testBackend)
 
 	blockFromDbByHash := testBackend.GetBlockByHash(block.Header().Hash().Hex())
 
@@ -127,7 +128,7 @@ func TestBlockByHash(t *testing.T) {
 func TestLatestBlocks(t *testing.T) {
 	testBackend := getBackend(t)
 	defer testBackend.mongo.cleanUp()
-	block := createImportBlock(testBackend)
+	block := createImportBlock(context.Background(), testBackend)
 
 	latestBlocks := testBackend.GetLatestsBlocks(0, 100)
 
@@ -142,7 +143,7 @@ func TestLatestBlocks(t *testing.T) {
 func TestActiveAddresses(t *testing.T) {
 	testBackend := getBackend(t)
 	defer testBackend.mongo.cleanUp()
-	block := createImportBlock(testBackend)
+	block := createImportBlock(context.Background(), testBackend)
 
 	activeNonContracts := testBackend.GetActiveAdresses(time.Unix(0, 0), false)
 
@@ -199,7 +200,7 @@ func TestRichList(t *testing.T) {
 func TestStats(t *testing.T) {
 	testBackend := getBackend(t)
 	defer testBackend.mongo.cleanUp()
-	_ = createImportBlock(testBackend)
+	_ = createImportBlock(context.Background(), testBackend)
 
 	testBackend.UpdateStats()
 	stats := testBackend.GetStats()
@@ -276,8 +277,8 @@ func TestInternalTransactions(t *testing.T) {
 
 	addrHash := "0x0000000000000000000000000000000000000000"
 
-	testBackend.ImportInternalTransaction(addrHash, transaction1)
-	testBackend.ImportInternalTransaction(addrHash, transaction2)
+	testBackend.ImportInternalTransaction(context.Background(), addrHash, transaction1)
+	testBackend.ImportInternalTransaction(context.Background(), addrHash, transaction2)
 
 	transactions := testBackend.GetInternalTransactionsList(addrHash, false, 0, 100)
 	token_transactions := testBackend.GetInternalTransactionsList(tokenHolderHash1, true, 0, 100)
@@ -300,7 +301,7 @@ func TestInternalTransactions(t *testing.T) {
 func TestReloadBlock(t *testing.T) {
 	testBackend := getBackend(t)
 	defer testBackend.mongo.cleanUp()
-	block := createImportBlock(testBackend)
+	block := createImportBlock(context.Background(), testBackend)
 	if !testBackend.NeedReloadParent(block.Header().Number.Int64()) {
 		t.Errorf("Block is wrong and should be reloaded")
 	}
@@ -309,7 +310,7 @@ func TestReloadBlock(t *testing.T) {
 func TestTransactionsConsistent(t *testing.T) {
 	testBackend := getBackend(t)
 	defer testBackend.mongo.cleanUp()
-	block := createImportBlock(testBackend)
+	block := createImportBlock(context.Background(), testBackend)
 	if !testBackend.TransactionsConsistent(block.Header().Number.Int64()) {
 		t.Errorf("Number of transactions is not consistent")
 	}

--- a/server/utils/sleep.go
+++ b/server/utils/sleep.go
@@ -1,0 +1,16 @@
+package utils
+
+import (
+	"context"
+	"time"
+)
+
+// SleepCtx is like time.Sleep(dur), but returns an error if the ctx is Done before then.
+func SleepCtx(ctx context.Context, dur time.Duration) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-time.After(dur):
+		return nil
+	}
+}


### PR DESCRIPTION
This PR adds signal interrupt cancellation and wires `context.Context` around so that processes shutdown swiftly and gracefully. Specifically, there are no more blocking `time.Sleep` or HTTP RPC requests.