### PR TITLE
warn instead of error for unsupported contracts

### DIFF
--- a/server/backend/db_backend.go
+++ b/server/backend/db_backend.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/gochain-io/explorer/server/models"
 	"github.com/gochain-io/explorer/server/tokens"
-	"github.com/gochain-io/explorer/server/utils"
 
 	"github.com/gochain/gochain/v3/common"
 	"github.com/gochain/gochain/v3/core/types"
@@ -282,16 +281,6 @@ func (self *MongoBackend) importAddress(address string, balance *big.Int, token 
 	if err != nil {
 		return nil, fmt.Errorf("failed to count held token txs: %v", err)
 	}
-
-	ercTypes := make([]utils.ErcName, 0, len(token.ErcTypes))
-	for erc := range token.ErcTypes {
-		ercTypes = append(ercTypes, erc)
-	}
-	functions := make([]utils.FunctionName, 0, len(token.Functions))
-	for fn := range token.Functions {
-		functions = append(functions, fn)
-	}
-
 	addressM := &models.Address{Address: address,
 		BalanceWei:     balance.String(),
 		UpdatedAt:      time.Now(),
@@ -301,8 +290,8 @@ func (self *MongoBackend) importAddress(address string, balance *big.Int, token 
 		Decimals:       token.Decimals,
 		TotalSupply:    token.TotalSupply.String(),
 		Contract:       contract,
-		ErcTypes:       ercTypes,
-		Interfaces:     functions,
+		ErcTypes:       token.ERCTypesSlice(),
+		Interfaces:     token.FunctionsSlice(),
 		BalanceFloat:   balanceGoFloat,
 		BalanceString:  balanceGoString,
 		// NumberOfTransactions:         transactionCounter,

--- a/server/models/address.go
+++ b/server/models/address.go
@@ -1,28 +1,27 @@
 package models
 
 import (
-	"github.com/gochain-io/explorer/server/utils"
 	"time"
 )
 
 type Address struct {
-	Address                      string               `json:"address" bson:"address"`
-	Owner                        string               `json:"owner,omitempty" bson:"owner"`
-	BalanceFloat                 float64              `json:"-" bson:"balance_float"`        //low precise balance for sorting purposes
-	BalanceString                string               `json:"balance" bson:"balance_string"` //high precise balance for API
-	BalanceWei                   string               `json:"balance_wei" bson:"balance_wei"`
-	UpdatedAt                    time.Time            `json:"updated_at" bson:"updated_at"`
-	UpdatedAtBlock               int64                `json:"-" bson:"updated_at_block"`
-	TokenName                    string               `json:"token_name,omitempty" bson:"token_name"`
-	TokenSymbol                  string               `json:"token_symbol,omitempty" bson:"token_symbol"`
-	Decimals                     int64                `json:"decimals,omitempty" bson:"decimals"`
-	TotalSupply                  string               `json:"total_supply" bson:"total_supply"`
-	Contract                     bool                 `json:"contract" bson:"contract"`
-	ErcTypes                     []utils.ErcName      `json:"erc_types" bson:"erc_types"`
-	Interfaces                   []utils.FunctionName `json:"interfaces" bson:"interfaces"`
-	NumberOfTransactions         int                  `json:"number_of_transactions" bson:"number_of_transactions"`
-	NumberOfTokenHolders         int                  `json:"number_of_token_holders,omitempty" bson:"number_of_token_holders"`
-	NumberOfInternalTransactions int                  `json:"number_of_internal_transactions,omitempty" bson:"number_of_internal_transactions"`
-	NumberOfTokenTransactions    int                  `json:"number_of_token_transactions,omitempty" bson:"number_of_token_transactions"`
-	AttachedContract             Contract             `json:"attached_contract,omitempty" bson:"attached_contract,omitempty"`
+	Address                      string    `json:"address" bson:"address"`
+	Owner                        string    `json:"owner,omitempty" bson:"owner"`
+	BalanceFloat                 float64   `json:"-" bson:"balance_float"`        //low precise balance for sorting purposes
+	BalanceString                string    `json:"balance" bson:"balance_string"` //high precise balance for API
+	BalanceWei                   string    `json:"balance_wei" bson:"balance_wei"`
+	UpdatedAt                    time.Time `json:"updated_at" bson:"updated_at"`
+	UpdatedAtBlock               int64     `json:"-" bson:"updated_at_block"`
+	TokenName                    string    `json:"token_name,omitempty" bson:"token_name"`
+	TokenSymbol                  string    `json:"token_symbol,omitempty" bson:"token_symbol"`
+	Decimals                     int64     `json:"decimals,omitempty" bson:"decimals"`
+	TotalSupply                  string    `json:"total_supply" bson:"total_supply"`
+	Contract                     bool      `json:"contract" bson:"contract"`
+	ErcTypes                     []string  `json:"erc_types" bson:"erc_types"`
+	Interfaces                   []string  `json:"interfaces" bson:"interfaces"`
+	NumberOfTransactions         int       `json:"number_of_transactions" bson:"number_of_transactions"`
+	NumberOfTokenHolders         int       `json:"number_of_token_holders,omitempty" bson:"number_of_token_holders"`
+	NumberOfInternalTransactions int       `json:"number_of_internal_transactions,omitempty" bson:"number_of_internal_transactions"`
+	NumberOfTokenTransactions    int       `json:"number_of_token_transactions,omitempty" bson:"number_of_token_transactions"`
+	AttachedContract             Contract  `json:"attached_contract,omitempty" bson:"attached_contract,omitempty"`
 }


### PR DESCRIPTION
This PR follows up from #396 to reduce the severity of unsupported contracts from error to warning, so that the addresses are still processed smoothly (we just store 0 transfers, instead of failing to look up transfers).