### PR TITLE
init map

### DIFF
--- a/grabber/main.go
+++ b/grabber/main.go
@@ -25,13 +25,6 @@ import (
 )
 
 func main() {
-	var rpcUrl string
-	var checkTxCount bool
-	var mongoUrl string
-	var dbName string
-	var startFrom int64
-	var blockRangeLimit uint64
-	var workersCount uint
 	cfg := zapdriver.NewProductionConfig()
 	cfg.EncoderConfig.TimeKey = "timestamp"
 	logger, err := cfg.Build()
@@ -40,6 +33,20 @@ func main() {
 		os.Exit(1)
 	}
 	defer logger.Sync()
+	defer func() {
+		if rerr := recover(); rerr != nil {
+			logger.Error("Fatal panic", zap.String("panic", fmt.Sprintf("%+v", rerr)))
+		}
+	}()
+
+	var rpcUrl string
+	var checkTxCount bool
+	var mongoUrl string
+	var dbName string
+	var startFrom int64
+	var blockRangeLimit uint64
+	var workersCount uint
+
 	app := cli.NewApp()
 	app.Usage = "Grabber populates a mongo database with explorer data."
 

--- a/server/tokens/tokens.go
+++ b/server/tokens/tokens.go
@@ -150,10 +150,10 @@ func (th *TokenHolderDetails) queryTokenHolderDetails(conn *goclient.Client, lgr
 	return err
 }
 
-var contractInfoCache struct {
+var contractInfoCache = struct {
 	sync.RWMutex
 	data map[common.Hash]contractInfo
-}
+}{data: make(map[common.Hash]contractInfo)}
 
 type contractInfo struct {
 	types map[utils.EVMInterface]struct{}


### PR DESCRIPTION
This PR fixes a problem from #404, and adds a top level `recover()` to log panics in a stackdriver compatible format.