### PR TITLE
enable full abi from interact

### DIFF
--- a/front/src/app/components/interactor/interactor.component.ts
+++ b/front/src/app/components/interactor/interactor.component.ts
@@ -42,7 +42,7 @@ export class InteractorComponent implements OnInit {
   });
 
   contractBadges: Badge[] = [];
-  abiTemplates = [ErcName.Go20, ErcName.Go721, ErcName.Go165, ErcName.AllFunctions];
+  abiTemplates = [ErcName.Go20, ErcName.Go721, ErcName.Go165, ErcName.Upgradeable, ErcName.AllFunctions];
 
   contract: Web3Contract;
   abiFunctions: AbiItem[];

--- a/front/src/app/components/interactor/interactor.component.ts
+++ b/front/src/app/components/interactor/interactor.component.ts
@@ -42,7 +42,7 @@ export class InteractorComponent implements OnInit {
   });
 
   contractBadges: Badge[] = [];
-  abiTemplates = [ErcName.Go20, ErcName.Go721, ErcName.Go165];
+  abiTemplates = [ErcName.Go20, ErcName.Go721, ErcName.Go165, ErcName.AllFunctions];
 
   contract: Web3Contract;
   abiFunctions: AbiItem[];

--- a/front/src/app/utils/constants.ts
+++ b/front/src/app/utils/constants.ts
@@ -97,6 +97,7 @@ export const TOKEN_TYPES = {
 };
 
 export const ERC_INTERFACE_IDENTIFIERS = {
+  [ErcName.AllFunctions]: Object.keys(FunctionName),
   [ErcName.Go20]: [FunctionName.Allowance, FunctionName.Approve, FunctionName.BalanceOf, FunctionName.TotalSupply, FunctionName.Transfer, FunctionName.TransferFrom],
   [ErcName.Go721]: [FunctionName.Approve, FunctionName.BalanceOf, FunctionName.GetApproved, FunctionName.IsApprovedForAll, FunctionName.OwnerOf, FunctionName.SafeTransferFrom, FunctionName.SafeTransferFromData, FunctionName.SetApprovalForAll, FunctionName.TransferFrom],
   [ErcName.Go165]: [FunctionName.SupportsInterface],

--- a/front/src/app/utils/constants.ts
+++ b/front/src/app/utils/constants.ts
@@ -101,6 +101,7 @@ export const ERC_INTERFACE_IDENTIFIERS = {
   [ErcName.Go20]: [FunctionName.Allowance, FunctionName.Approve, FunctionName.BalanceOf, FunctionName.TotalSupply, FunctionName.Transfer, FunctionName.TransferFrom],
   [ErcName.Go721]: [FunctionName.Approve, FunctionName.BalanceOf, FunctionName.GetApproved, FunctionName.IsApprovedForAll, FunctionName.OwnerOf, FunctionName.SafeTransferFrom, FunctionName.SafeTransferFromData, FunctionName.SetApprovalForAll, FunctionName.TransferFrom],
   [ErcName.Go165]: [FunctionName.SupportsInterface],
+  [ErcName.Upgradeable]: [FunctionName.Target, FunctionName.Upgrade, FunctionName.Pause, FunctionName.Paused, FunctionName.Resume, FunctionName.Owner],
 };
 
 export const TOKEN_ABI_NAMES: string[] = ['totalSupply', 'balanceOf'];

--- a/front/src/app/utils/enums.ts
+++ b/front/src/app/utils/enums.ts
@@ -47,6 +47,7 @@ export enum FunctionName {
   IsSuperseded = 'IsSuperseded',
   IsVerified = 'IsVerified',
   Mint = 'Mint',
+  MintWithTokenURI = 'MintWithTokenURI',
   Name = 'Name',
   OnErc721Received = 'OnErc721Received',
   OnErc1155BatchReceived = 'OnErc1155BatchReceived',
@@ -86,11 +87,11 @@ export enum FunctionName {
   Paused = 'Paused',
   Unpause = 'Unpause',
   Upgrade = 'Upgrade',
-  MintWithTokenURI = 'MintWithTokenURI',
   Resume = 'Resume',
 }
 
 export enum ErcName {
+  AllFunctions = 'AllFunctions',
   Go20 = 'Go20',
   Go20Burnable = 'Go20Burnable',
   Go20Capped = 'Go20Capped',

--- a/front/src/assets/data/abi.json
+++ b/front/src/assets/data/abi.json
@@ -880,6 +880,20 @@
     "stateMutability": "nonpayable",
     "type": "function"
   },
+  "Owner": {
+    "constant": true,
+    "inputs": [],
+    "name": "owner",
+    "outputs": [
+      {
+        "name": "owner",
+        "type": "address"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
   "OwnerOf": {
     "constant": true,
     "inputs": [
@@ -1102,6 +1116,20 @@
       {
         "name": "",
         "type": "string"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  "Target": {
+    "constant": true,
+    "inputs": [],
+    "name": "target",
+    "outputs": [
+      {
+        "name": "addr",
+        "type": "address"
       }
     ],
     "payable": false,
@@ -1540,6 +1568,29 @@
     "constant": false,
     "inputs": [],
     "name": "pause",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  "Upgrade": {
+    "constant": false,
+    "inputs": [
+      {
+        "name": "target",
+        "type": "address"
+      }
+    ],
+    "name": "upgrade",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  "Resume": {
+    "constant": false,
+    "inputs": [],
+    "name": "resume",
     "outputs": [],
     "payable": false,
     "stateMutability": "nonpayable",


### PR DESCRIPTION
This PR proposes adding `AllFunctions` and `Upgradeable` options to the contract interaction templates (and fills in a few missing functions). It would be neat to have an additional option dynamically generated with functions recognized by the bytecode scan, but we can do that later, and this will still be useful if/when we do.