### PR TITLE
improve empty and error contract interactions

### DIFF
--- a/front/src/app/components/interactor/interactor.component.html
+++ b/front/src/app/components/interactor/interactor.component.html
@@ -109,7 +109,10 @@
   </ng-container>
   <div *ngIf="functionResult">
     <h4>Response</h4>
-    <div *ngFor="let k of functionResult">
+    <div *ngIf="functionResult.error">
+      {{functionResult.error}}
+    </div>
+    <div *ngFor="let k of functionResult.output">
       {{k[0]}}: <span style="font-weight: bold;">{{k[1]}}</span>
     </div>
   </div>

--- a/front/src/app/components/interactor/interactor.component.ts
+++ b/front/src/app/components/interactor/interactor.component.ts
@@ -48,7 +48,7 @@ export class InteractorComponent implements OnInit {
   contract: Web3Contract;
   abiFunctions: AbiItem[];
   selectedFunction: AbiItem;
-  functionResult: any[][];
+  functionResult: {output:any[][], error: string};
   addr: Address;
 
   hasData = false;
@@ -175,9 +175,13 @@ export class InteractorComponent implements OnInit {
    */
   callABIFunction(func: AbiItem, params: string[] = []): void {
     this._walletService.call(this.contract.options.address, func, params).subscribe((decoded: object) => {
-      this.functionResult = getDecodedData(decoded, func, this.addr);
+      if (!decoded) {
+        this.functionResult = {error:'Result is empty', output:null};
+        return;
+      }
+      this.functionResult = {output:getDecodedData(decoded, func, this.addr), error: null};
     }, err => {
-      this._toastrService.danger(err);
+      this.functionResult = {error:err, output:null};
     });
   }
 

--- a/front/src/app/services/wallet.service.ts
+++ b/front/src/app/services/wallet.service.ts
@@ -107,12 +107,12 @@ export class WalletService {
           data: encoded,
         }))
       }),map((res: string) => {
-        if (!res) {
-          throw new Error('Result is empty');
+        if (!res || res==='0x' || res==='0X') {
+          return null;
         }
-        const decoded: object = web3.eth.abi.decodeLog(abi.outputs, res, []);
+        const decoded: object = web3.eth.abi.decodeParameters(abi.outputs, res);
         if (objIsEmpty(decoded)) {
-          throw new Error('Result is empty');
+          return null;
         }
         return decoded;
       })


### PR DESCRIPTION
This PR changes contract interactions for empty and error responses from temporary toasts:
![Screenshot from 2019-10-14 18-53-54](https://user-images.githubusercontent.com/1194128/66790100-06f8bf80-eeb4-11e9-99ae-851412495c60.png)

![Screenshot from 2019-10-14 18-54-08](https://user-images.githubusercontent.com/1194128/66790101-08c28300-eeb4-11e9-97c2-ba0fd4737a45.png)

...to inline messages were the output would normally be:
![Screenshot from 2019-10-14 18-55-30](https://user-images.githubusercontent.com/1194128/66790149-3b6c7b80-eeb4-11e9-824d-2631299e08d9.png)

![Screenshot from 2019-10-14 18-51-37](https://user-images.githubusercontent.com/1194128/66790104-0ceea080-eeb4-11e9-8d40-31a1515d3b9d.png)


https://testnet-explorer.gochain.io/addr/0x891fB47663B9df0321aD480f5ddAC0AaF90520e0