### PR TITLE
don't warn about non-token contracts

### DIFF
--- a/server/tokens/tokens.go
+++ b/server/tokens/tokens.go
@@ -247,8 +247,6 @@ func (rpc *TokenClient) GetTransferEvents(ctx context.Context, tokenDetails *Tok
 	} else if _, ok := tokenDetails.ErcTypes[utils.Go721]; ok {
 		unpackTransferEvent = unpackERC721TransferEvent
 	} else {
-		lgr.Warn("Unsupported contract type", zap.Strings("ercTypes", tokenDetails.ERCTypesSlice()),
-			zap.Strings("functions", tokenDetails.FunctionsSlice()))
 		return nil, nil
 	}
 


### PR DESCRIPTION
This PR removes an uninteresting and noisy log line. We don't really care about this event, and the fields are already logged INFO before this:
![Screenshot from 2019-10-15 08-27-51](https://user-images.githubusercontent.com/1194128/66835783-c20d7100-ef25-11e9-9633-cdec9facde03.png)