### PR TITLE
remove unused fields; docs

### DIFF
--- a/front/src/app/models/block.model.ts
+++ b/front/src/app/models/block.model.ts
@@ -1,11 +1,12 @@
 import {SignerDetails} from './signer-node';
 
 export class Extra {
-  auth: boolean;
   vanity: string;
-  has_vote: boolean;
-  candidate: string;
-  is_voter_election: boolean;
+
+  has_vote: boolean; // If true, then the remaining vote fields are included.
+  auth: boolean; // Whether voting to authorize (add) or deauthorize (remove).
+  is_voter_election: boolean; // Whether voting on voter (true) or signer (false) auth.
+  candidate: string; // Candidate address.
   signerDetails?: SignerDetails;
 }
 
@@ -18,9 +19,7 @@ export class Block {
   gas_used: any;
   miner: any;
   difficulty: any;
-  sha3_uncles: any;
   extra_data: any;
-  nonce: number;
   gas_limit: number;
   extra: Extra;
   signerDetails?: SignerDetails;

--- a/front/src/app/scenes/block/block.component.html
+++ b/front/src/app/scenes/block/block.component.html
@@ -23,8 +23,6 @@
           <dd>{{block.gas_limit | bigNumber}}</dd>
           <dt>Gas Used</dt>
           <dd>{{block.gas_used | bigNumber}}</dd>
-          <dt>Nonce</dt>
-          <dd>{{block.nonce}}</dd>
           <dt>Transactions Count</dt>
           <dd>{{block.tx_count}}</dd>
           <dt>Difficulty</dt>


### PR DESCRIPTION
This PR removes `Nonce` from the block page (it is only populated for votes, and already interpreted elsewhere), and does some other cleanup.
![Screenshot from 2019-10-25 08-21-02](https://user-images.githubusercontent.com/1194128/67574618-65b60880-f700-11e9-8627-649cb0fb4eda.png)
