### PR TITLE
display txs to self differently

### DIFF
--- a/front/src/app/components/addr-transactions/addr-transactions.component.html
+++ b/front/src/app/components/addr-transactions/addr-transactions.component.html
@@ -23,13 +23,19 @@
             Associate:
           </div>
           <div class="data-list-desc">
-            <ng-container *ngIf="addr.address === tx.to; else out">
+            <ng-container *ngIf="addr.address !== tx.from; else out">
               <img src="../../../assets/icons/left.svg" alt="From">
               <a routerLink="/addr/{{tx.from}}">{{tx.from}}</a>
             </ng-container>
             <ng-template #out>
-              <img src="../../../assets/icons/right.svg" alt="To">
-              <a routerLink="/addr/{{tx.to}}">{{tx.to}}</a>
+              <ng-container *ngIf="addr.address !== tx.to; else self">
+                <img src="../../../assets/icons/right.svg" alt="To">
+                <a routerLink="/addr/{{tx.to}}">{{tx.to}}</a>
+              </ng-container>
+              <ng-template #self>
+                <img src="../../../assets/icons/minus.svg" alt="Self">
+                self
+              </ng-template>
             </ng-template>
           </div>
         </div>
@@ -38,7 +44,7 @@
             Value (GO):
           </div>
           <div class="data-list-desc">
-            {{addr.address === tx.to ? '+' : '-'}} {{tx.value | weiToGO: false : false | bigNumber}}
+            {{tx.from === tx.to ? '+/-' : addr.address === tx.to ? '+' : '-'}} {{tx.value | weiToGO: false : false | bigNumber}}
           </div>
         </div>
       </div>
@@ -63,7 +69,7 @@
         <td class="text-truncate">
           {{tx.created_at | date: 'yyyy/MM/dd HH:mm:ss'}} ({{tx.created_at | timeAgo}})
         </td>
-        <ng-container *ngIf="addr.address === tx.to; else out">
+        <ng-container *ngIf="addr.address !== tx.from; else out">
           <td>
             <img src="../../../assets/icons/left.svg" alt="From">
           </td>
@@ -72,15 +78,25 @@
           </td>
         </ng-container>
         <ng-template #out>
-          <td>
-            <img src="../../../assets/icons/right.svg" alt="To">
-          </td>
-          <td class="text-monospace text-truncate">
-            <a class="ws-p" routerLink="/addr/{{tx.to}}">{{tx.to}}</a>
-          </td>
+          <ng-container *ngIf="addr.address !== tx.to; else self">
+            <td>
+              <img src="../../../assets/icons/right.svg" alt="To">
+            </td>
+            <td class="text-monospace text-truncate">
+              <a class="ws-p" routerLink="/addr/{{tx.to}}">{{tx.to}}</a>
+            </td>
+          </ng-container>
+          <ng-template #self>
+            <td>
+              <img src="../../../assets/icons/minus.svg" alt="Self">
+            </td>
+            <td class="text-monospace text-truncate">
+              self
+            </td>
+          </ng-template>
         </ng-template>
         <td class="text-nowrap text-right text-monospace ws-p">
-          {{addr.address === tx.to ? '+' : tx.value === '0' ? '' : '-'}} {{tx.value | weiToGO: false : true | bigNumber}}
+          {{tx.value === '0' ? '' : tx.from === tx.to ? '+/-' : addr.address === tx.to ? '+' : '-'}} {{tx.value | weiToGO: false : true | bigNumber}}
         </td>
       </tr>
       </tbody>

--- a/front/src/assets/icons/minus.svg
+++ b/front/src/assets/icons/minus.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M8 12L16 12" stroke="black" stroke-opacity="0.87" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>


### PR DESCRIPTION
This PR adds special formatting for txs sent to self, so that they don't appear as incoming:
![Screenshot from 2019-10-25 09-34-11](https://user-images.githubusercontent.com/1194128/67579881-f1cd2d80-f70a-11e9-9b8c-c2fd809bf0a6.png)
![Screenshot from 2019-10-25 09-34-29](https://user-images.githubusercontent.com/1194128/67579887-f396f100-f70a-11e9-82a7-295fdc637754.png)
https://testnet-explorer.gochain.io/tx/0xd3525466bdb16ea1c4bec4a02d929108a73621e1ad836ae72cbade2b5322deb9

Fixes #375 

Open to suggestions for alternatives to `self` text and the icon (I just coded a horizontal line).