### PR TITLE
reduced the size of the batch

### DIFF
--- a/server/backend/db_migrations.go
+++ b/server/backend/db_migrations.go
@@ -42,7 +42,7 @@ var migrationTransactionsByAddress = migrate.Migration{
 		txs := find.Iter()
 		defer txs.Close()
 
-		const batchUpsertSize = 1000
+		const batchUpsertSize = 500
 		bulk := d.C("TransactionsByAddress").Bulk()
 		bulk.Unordered()
 


### PR DESCRIPTION
BSONObj size: 16801548 (0x1005F0C) is invalid. Size must be between 0 and 16793600(16MB)