### PR TITLE
support solc evm-version when verifying contracts

### DIFF
--- a/front/src/app/components/contract-source/contract-source.component.html
+++ b/front/src/app/components/contract-source/contract-source.component.html
@@ -19,6 +19,7 @@
     <h5 class="uk-margin uk-margin-large-top"><i class="fas fa-code"></i> Contract Source Code</h5>
     <p>Contract Name: {{contract.contract_name}}</p>
     <p>Compiler Version: {{contract.compiler_version}}</p>
+    <p>EVM Version: {{contract.evm_version}}</p>
     <p>Optimization: {{contract.optimization}}</p>
     <p>Verified: {{contract.updated_at | date: 'yyyy/MM/dd HH:mm:ss'}} ({{contract.updated_at | timeAgo}}
       )</p>

--- a/front/src/app/models/contract.model.ts
+++ b/front/src/app/models/contract.model.ts
@@ -6,6 +6,7 @@ export class Contract {
   valid: boolean;
   contract_name: string;
   compiler_version: string;
+  evm_version: string;
   optimization: boolean;
   source_code: string;
   abi: AbiItem[];

--- a/front/src/app/scenes/contract/contract.component.html
+++ b/front/src/app/scenes/contract/contract.component.html
@@ -47,6 +47,21 @@
             <option *ngFor="let compiler of compilers">{{compiler}}</option>
           </select>
         </div>
+        <div class="form-group">
+          <label for="evm">EVM</label>
+          <select
+              class="form-control"
+              id="evm"
+              formControlName="evm_version">
+            <option value="" selected>Default</option>
+            <option value="homestead">Homestead</option>
+            <option value="tangerineWhistle">Tangerine Whistle</option>
+            <option value="spuriousDragon">Spurious Dragon</option>
+            <option value="byzantium">Byzantium</option>
+            <option value="constantinople">Constantinople</option>
+            <option value="petersburg">Petersburg</option>
+          </select>
+        </div>
         <div class="form-group form-check">
           <input
               type="checkbox"

--- a/front/src/app/scenes/contract/contract.component.ts
+++ b/front/src/app/scenes/contract/contract.component.ts
@@ -30,6 +30,7 @@ export class ContractComponent implements OnInit {
     address: ['', [Validators.required, Validators.minLength(42), Validators.maxLength(42)]],
     contract_name: ['', Validators.required],
     compiler_version: ['', Validators.required],
+    evm_version: [''],
     optimization: [true, Validators.required],
     source_code: ['', Validators.required],
     /*recaptcha_token: null,*/

--- a/front/src/app/services/api.service.ts
+++ b/front/src/app/services/api.service.ts
@@ -69,4 +69,3 @@ export class ApiService {
     return of(null);
   };
 }
-

--- a/server/backend/solc_test.go
+++ b/server/backend/solc_test.go
@@ -1,0 +1,61 @@
+package backend
+
+import (
+	"testing"
+)
+
+func TestSolcBinEqual(t *testing.T) {
+	type test = testSolcBinEqual
+	t.Run("empty", test{
+		a: "",
+		b: "",
+	}.run)
+	t.Run("0x", test{
+		a: "0x1",
+		b: "1",
+	}.run)
+	t.Run("meta", test{
+		a: "1234",
+		b: "1234056fea165627a7a7230582086a6b3c7c6b942a6bcf7e8ea07686953fe563275da0b17537439e884054eede40029",
+	}.run)
+	t.Run("meta-empty", test{
+		a: "1234",
+		b: "1234056fea165627a7a723058200029",
+	}.run)
+	t.Run("suffix", test{
+		a: "1234cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdabcdefghi",
+		b: "1234abababababababababababababababababababababababababababababab123456789",
+	}.run)
+	t.Run("0x-suffix-meta", test{
+		a: "1234cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdabcdefghi056fea165627a7a72305820ABCDE0029",
+		b: "0x1234abababababababababababababababababababababababababababababab123456789",
+	}.run)
+
+	t.Run("meta-suffix", test{
+		a:        "12345678",
+		b:        "1234056fea165627a7a7230582000295678",
+		mismatch: true,
+	}.run)
+	t.Run("meta-multi", test{
+		a:        "1234567890",
+		b:        "1234056fea165627a7a723058200029567056fea165627a7a723058200029890",
+		mismatch: true,
+	}.run)
+}
+
+type testSolcBinEqual struct {
+	a, b     string
+	mismatch bool
+}
+
+func (tt testSolcBinEqual) run(t *testing.T) {
+	if SolcBinEqual(tt.a, tt.b) {
+		if tt.mismatch {
+			t.Error("expected mismatch")
+		}
+	} else {
+		if !tt.mismatch {
+			t.Error("expected match")
+		}
+	}
+}

--- a/server/models/contract.go
+++ b/server/models/contract.go
@@ -1,8 +1,9 @@
 package models
 
 import (
-	"github.com/gochain-io/explorer/server/utils"
 	"time"
+
+	"github.com/gochain-io/explorer/server/utils"
 )
 
 type Contract struct {
@@ -11,6 +12,7 @@ type Contract struct {
 	Valid           bool            `json:"valid" bson:"valid,omitempty"`
 	ContractName    string          `json:"contract_name" bson:"contract_name,omitempty"`
 	CompilerVersion string          `json:"compiler_version" bson:"compiler_version,omitempty"`
+	EVMVersion      string          `json:"evm_version" bson:"evm_version,omitempty"`
 	Optimization    bool            `json:"optimization" bson:"optimization,omitempty"`
 	SourceCode      string          `json:"source_code" bson:"source_code,omitempty"`
 	CreatedAt       time.Time       `json:"created_at" bson:"created_at"`


### PR DESCRIPTION
Adds a dropdown to the UI to optionally select and EVM version:
![Screenshot from 2020-01-27 09-31-47](https://user-images.githubusercontent.com/1194128/73188030-e3b2f280-40e7-11ea-94e9-a17fc7083dae.png)
Example request:
![Screenshot from 2020-01-27 09-31-56](https://user-images.githubusercontent.com/1194128/73188035-e6154c80-40e7-11ea-8095-33b8dd1ef65a.png)
`Default` is blank string, which uses the old behavior of no flag, so all the existing entries are forward compatible.
