### PR TITLE
bumping mongo timeout

### DIFF
--- a/server/backend/db_backend.go
+++ b/server/backend/db_backend.go
@@ -39,7 +39,7 @@ type MongoBackend struct {
 func NewMongoClient(client *goclient.Client, host, dbName string, lgr *zap.Logger) (*MongoBackend, error) {
 	session, err := mgo.DialWithInfo(&mgo.DialInfo{
 		Addrs:   []string{host},
-		Timeout: 120 * time.Second,
+		Timeout: 240 * time.Second,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to dial mongo: %v", err)

--- a/server/backend/db_backend.go
+++ b/server/backend/db_backend.go
@@ -589,8 +589,8 @@ func (self *MongoBackend) getTransactionList(address string, filter *models.TxsF
 			},
 		}
 		query := []bson.M{
-			{"$match": findQuery},
 			{"$sort": bson.M{"created_at": -1}},
+			{"$match": findQuery},
 			{"$skip": filter.Skip},
 			{"$limit": filter.Limit},
 			{"$lookup": bson.M{


### PR DESCRIPTION
- The problem - after mongo query timeout mongo lose a session and all subsequent requests are failing
- The root cause - despite of that we switched to TransactionsByAdress on the first request mongo tries to read index (~200G) into memory and it takes time (2-2.5 minutes) which leads to the session reset.
- The solution - the proper one would be to force mongo to keep index hot, but the only way to do this  run queries against this index, so I want to try to just bump timeout

Pages that lead to timeouts 

- https://testnet-explorer.gochain.io/addr/0x32418aE230050249a821a0A83Bf294c4006AbA59?addr_tab=transactions
- https://testnet-explorer.gochain.io/addr/0x7e2404728231924Cf8266EF46ECa0F4791C25674?addr_tab=transactions