### PR TITLE
add gas fees field to blocks; remove eth_totalSupply dependency

### DIFF
--- a/admin/main.go
+++ b/admin/main.go
@@ -77,7 +77,6 @@ func main() {
 			Destination: &dbName,
 		},
 	}
-	var network web3.Network
 	var backendInstance *backend.Backend
 	app.Before = func(*cli.Context) error {
 		var err error
@@ -92,7 +91,7 @@ func main() {
 				fatalExit(fmt.Errorf("%+v", rerr))
 			}
 		}()
-		network = getNetwork(netName, rpcUrl, testnet)
+		network := getNetwork(netName, rpcUrl, testnet)
 		backendInstance, err = backend.NewBackend(ctx, mongoUrl, network.URL, dbName, nil, nil, logger, nil)
 		if err != nil {
 			fatalExit(err)

--- a/front/src/app/scenes/block/block.component.html
+++ b/front/src/app/scenes/block/block.component.html
@@ -23,6 +23,10 @@
           <dd>{{block.gas_limit | bigNumber}}</dd>
           <dt>Gas Used</dt>
           <dd>{{block.gas_used | bigNumber}}</dd>
+          <ng-container *ngIf="block.gas_fees">
+            <dt>Gas Fees</dt>
+            <dd>{{block.gas_fees | weiToGO | bigNumber}}</dd>
+          </ng-container>
           <dt>Transactions Count</dt>
           <dd>{{block.tx_count}}</dd>
           <dt>Difficulty</dt>

--- a/server/backend/backend_test.go
+++ b/server/backend/backend_test.go
@@ -426,7 +426,7 @@ func TestTransactionsConsistent(t *testing.T) {
 	testBackend := getBackend(t)
 	defer testBackend.mongo.cleanUp()
 	block := createImportBlock(t, testBackend)
-	if ok, err := testBackend.TransactionsConsistent(block.Header().Number.Int64()); err != nil {
+	if _, ok, err := testBackend.InternalTxsConsistent(block.Header().Number.Int64()); err != nil {
 		t.Fatalf("Failed to check block: %v", err)
 	} else if !ok {
 		t.Error("Number of transactions is not consistent")

--- a/server/models/block.go
+++ b/server/models/block.go
@@ -22,6 +22,9 @@ type Block struct {
 	// Transactions    []string  `json:"transactions" bson:"transactions"`
 
 	Extra ExtraDataStruct `json:"extra" bson:"-"`
+
+	GasFees         string `json:"gas_fees" bson:"gas_fees"`                   // Sum of this block's tx fees.
+	TotalFeesBurned string `json:"total_fees_burned" bson:"total_fees_burned"` // Cumulative sum over chain including this block.
 }
 
 type LightBlock struct {


### PR DESCRIPTION
This change adds a gas fees field to blocks (as well as some other minor changes) in preparation for calculating total supply after GIP 30.
A follow up change is required to implement the `TotalFeesBurned` calculation, and to pick up the `ChainConfig` after the gochain repo is updated with the fork information. However, we could merge this first since `Gas Fees` is interesting block meta data regardless of whether the fork is applied.