### PR TITLE
do not tolerate failed receipt imports

### DIFF
--- a/grabber/darvaza.go
+++ b/grabber/darvaza.go
@@ -70,7 +70,7 @@ func fillTotalFees(ctx context.Context, b *backend.Backend, parent *models.Block
 		}
 		gasFees, ok := new(big.Int).SetString(bl.GasFees, 10)
 		if !ok {
-			b.Lgr.Error("Fees: Failed to parse gas fee", zap.Int64("number", bl.Number), zap.String("total", bl.GasFees))
+			b.Lgr.Error("Fees: Failed to parse block total gas fees", zap.Int64("number", bl.Number), zap.String("total", bl.GasFees))
 			return
 		}
 		bl.TotalFeesBurned = new(big.Int).Add(parentTotal, gasFees).String()


### PR DESCRIPTION
When we failed to get a receipt or parse part of it, the tx would be left with all or some receipt fields empty, but would still return to the caller who has no way of knowing if the receipt fields are correct, and could end up propagating corrupted data throughout the rest of the system (or just crashing).