### PR TITLE
backfill: read blocks as-is

### DIFF
--- a/admin/main.go
+++ b/admin/main.go
@@ -192,7 +192,7 @@ func ReloadBlock(ctx context.Context, backendInstance *backend.Backend, blockID 
 			fatalExit(err)
 		}
 		logger.Info("Reimporting block ", zap.String("number", blockID))
-		block, err = backendInstance.GetBlockByNumber(ctx, bnum)
+		block, err = backendInstance.GetBlockByNumber(ctx, bnum, false)
 	}
 	if err != nil {
 		fatalExit(fmt.Errorf("Failed to get block:%s, %v", blockID, err))
@@ -216,7 +216,7 @@ func ReloadTransaction(ctx context.Context, backendInstance *backend.Backend, tx
 	if err != nil {
 		fatalExit(err)
 	}
-	_, err = backendInstance.GetBlockByNumber(ctx, tx.BlockNumber)
+	_, err = backendInstance.GetBlockByNumber(ctx, tx.BlockNumber, false)
 	if err != nil {
 		fatalExit(fmt.Errorf("Failed to get block:%d, %v", tx.BlockNumber, err))
 	}

--- a/grabber/darvaza.go
+++ b/grabber/darvaza.go
@@ -23,7 +23,7 @@ func fillTotalFees(ctx context.Context, b *backend.Backend, parent *models.Block
 			b.Lgr.Info("Fees: Filled total fees up to latest")
 			return
 		}
-		bl, err := b.GetBlockByNumber(ctx, parent.Number+1)
+		bl, err := b.GetBlockByNumber(ctx, parent.Number+1, false)
 		if err != nil {
 			b.Lgr.Warn("Fees: Failed to get block", zap.Int64("number", parent.Number+1))
 			if utils.SleepCtx(ctx, 5*time.Second) != nil {

--- a/grabber/main.go
+++ b/grabber/main.go
@@ -220,7 +220,7 @@ func backfill(ctx context.Context, b *backend.Backend, blockNumber int64, checkE
 			logger.Info("Backfill: Progress")
 		}
 		var backfill bool
-		dbBlock, err := b.GetBlockByNumber(ctx, blockNumber)
+		dbBlock, err := b.GetBlockByNumber(ctx, blockNumber, true)
 		if err != nil {
 			logger.Error("Backfill: Failed to get block", zap.Error(err))
 			if utils.SleepCtx(ctx, 5*time.Second) != nil {

--- a/server/backend/backend_test.go
+++ b/server/backend/backend_test.go
@@ -73,7 +73,7 @@ func TestImportBlockTransaction(t *testing.T) {
 	testBackend := getBackend(t)
 	defer testBackend.mongo.cleanUp()
 	block := createImportBlock(t, testBackend)
-	blockFromDb, err := testBackend.GetBlockByNumber(context.Background(), block.Header().Number.Int64())
+	blockFromDb, err := testBackend.GetBlockByNumber(context.Background(), block.Header().Number.Int64(), false)
 	if err != nil {
 		t.Fatalf("failed to get block: %v", err)
 	}

--- a/server/main.go
+++ b/server/main.go
@@ -699,7 +699,7 @@ func getBlock(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		block, err = backendInstance.GetBlockByHash(r.Context(), param)
 	} else {
-		block, err = backendInstance.GetBlockByNumber(r.Context(), bnum)
+		block, err = backendInstance.GetBlockByNumber(r.Context(), bnum, false)
 	}
 	if err != nil {
 		logger.Error("Failed to get block", zap.String("num", param), zap.Error(err))


### PR DESCRIPTION
`GetBlockByNumber` auto-imports/reimports blocks in some cases, but that is not always appropriate. Some callers expect to get back a nil or stale block to inspect themselves. This changes adds an `asIs bool` so that those callers can by-pass.