### PR TITLE
server/backend: fix total supply nil pointer

### DIFF
--- a/server/backend/backend.go
+++ b/server/backend/backend.go
@@ -147,7 +147,8 @@ func (b *Backend) TotalSupply(ctx context.Context) (*big.Int, error) {
 			if err != nil {
 				return err
 			}
-			b.alloc.Store(result.Total())
+			alloc = result.Total()
+			b.alloc.Store(alloc)
 			return nil
 		}); err != nil {
 			return nil, err


### PR DESCRIPTION
This was causing a nil pointer only on the first call, but then would have the value cached afterwards.