### PR TITLE
server: string encode supply stats

### DIFF
--- a/server/models/supply.go
+++ b/server/models/supply.go
@@ -1,10 +1,35 @@
 package models
 
-import "math/big"
+import (
+	"encoding/json"
+	"math/big"
+)
 
 type SupplyStats struct {
-	Total       *big.Int `json:"total"`
-	Circulating *big.Int `json:"circulating"`
-	Locked      *big.Int `json:"locked"`
-	FeesBurned  *big.Int `json:"fees_burned"`
+	Total       *big.Int
+	Circulating *big.Int
+	Locked      *big.Int
+	FeesBurned  *big.Int
+}
+
+func (s *SupplyStats) MarshalJSON() ([]byte, error) {
+	var encoded = struct {
+		Total       string `json:"total,omitempty"`
+		Circulating string `json:"circulating,omitempty"`
+		Locked      string `json:"locked,omitempty"`
+		FeesBurned  string `json:"fees_burned,omitempty"`
+	}{}
+	if s.Total != nil {
+		encoded.Total = s.Total.String()
+	}
+	if s.Circulating != nil {
+		encoded.Circulating = s.Circulating.String()
+	}
+	if s.Locked != nil {
+		encoded.Locked = s.Locked.String()
+	}
+	if s.FeesBurned != nil {
+		encoded.FeesBurned = s.FeesBurned.String()
+	}
+	return json.Marshal(encoded)
 }


### PR DESCRIPTION
String encode the supply stats fields to maintain precision and compatibility with our formatters.