### PR TITLE
add erc721 token history query

### DIFF
--- a/server/backend/db_backend.go
+++ b/server/backend/db_backend.go
@@ -132,6 +132,7 @@ func (mb *MongoBackend) createIndexes() error {
 		{c: "TokenHolders", index: mgo.Index{Key: []string{"token_holder_address"}, Background: true, Sparse: true}},
 		{c: "TokenHolders", index: mgo.Index{Key: []string{"balance_int"}, Background: true, Sparse: true}},
 		{c: "InternalTransactions", index: mgo.Index{Key: []string{"contract_address", "from_address", "to_address"}, Background: true, Sparse: true}},
+		{c: "InternalTransactions", index: mgo.Index{Key: []string{"contract_address", "value"}, Background: true, Sparse: true}},
 		{c: "InternalTransactions", index: mgo.Index{Key: []string{"from_address", "block_number"}, Background: true}},
 		{c: "InternalTransactions", index: mgo.Index{Key: []string{"to_address", "block_number"}, Background: true}},
 		{c: "InternalTransactions", index: mgo.Index{Key: []string{"transaction_hash"}, Background: true, Sparse: true}},
@@ -762,6 +763,8 @@ func (mb *MongoBackend) getInternalTokenTransfers(contractAddress string, filter
 	query := bson.M{"contract_address": contractAddress}
 	if filter.InternalAddress != "" {
 		query = bson.M{"contract_address": contractAddress, "$or": []bson.M{{"from_address": filter.InternalAddress}, {"to_address": filter.InternalAddress}}}
+	} else if filter.TokenID != "" {
+		query = bson.M{"contract_address": contractAddress, "value": filter.TokenID}
 	}
 	err := mb.mongo.C("InternalTransactions").
 		Find(query).

--- a/server/main.go
+++ b/server/main.go
@@ -546,6 +546,10 @@ func getInternalTransactions(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	} else {
+		if filter.InternalAddress != "" && filter.TokenID != "" {
+			errorResponse(w, http.StatusBadRequest, fmt.Errorf("only one of internal_address and token_id may be used"))
+			return
+		}
 		tokenTransfers.Transfers, err = backendInstance.GetInternalTokenTransfers(contractAddress, filter)
 		if err != nil {
 			logger.Error("Failed to get contract's internal token transfers", zap.String("address", contractAddress), zap.Error(err))

--- a/server/models/internal_transactions.go
+++ b/server/models/internal_transactions.go
@@ -7,7 +7,7 @@ type TokenTransfer struct {
 	Contract        string    `json:"contract_address" bson:"contract_address"`
 	From            string    `json:"from_address" bson:"from_address"`
 	To              string    `json:"to_address" bson:"to_address"`
-	Value           string    `json:"value" bson:"value"`
+	Value           string    `json:"value" bson:"value"` // or token ID for erc721
 	BlockNumber     int64     `json:"block_number" bson:"block_number"`
 	TransactionHash string    `json:"transaction_hash" bson:"transaction_hash"`
 	UpdatedAt       time.Time `json:"updated_at" bson:"updated_at"`

--- a/server/models/request_filters.go
+++ b/server/models/request_filters.go
@@ -57,6 +57,7 @@ type InternalTxFilter struct {
 	PaginationFilter
 	TokenTransactions bool   `schema:"token_transactions,omitempty"`
 	InternalAddress   string `schema:"internal_address,omitempty"`
+	TokenID           string `schema:"token_id,omitempty"`
 }
 
 type TxsFilter struct {


### PR DESCRIPTION
This PR adds a `token_id` option to the `/internal_transactions` service to filter for a single NFT.