### PR TITLE
don't log fatal for http.ErrServerClosed; warn about close errors

### DIFF
--- a/grabber/main.go
+++ b/grabber/main.go
@@ -259,6 +259,9 @@ func backfill(ctx context.Context, b *backend.Backend, blockNumber int64, checkE
 				continue
 			}
 			if bl, err := b.ImportBlock(ctx, rpcBlock); err != nil {
+				if ctx.Err() != nil {
+					return
+				}
 				logger.Error("Backfill: Failed to import block", zap.Error(err))
 				if utils.SleepCtx(ctx, 5*time.Second) != nil {
 					return

--- a/server/main.go
+++ b/server/main.go
@@ -254,10 +254,17 @@ func main() {
 		go func() {
 			select {
 			case <-ctx.Done():
-				server.Close()
+				if err := server.Close(); err != nil {
+					logger.Warn("Error closing server", zap.Error(err))
+				}
 			}
 		}()
-		return server.ListenAndServe()
+		switch err := server.ListenAndServe(); err {
+		case nil, http.ErrServerClosed:
+			return nil
+		default:
+			return err
+		}
 
 	}
 	err = app.Run(os.Args)


### PR DESCRIPTION
Normal shutdown of the http server returns `http.ErrServerClosed`, which we just see as an error and log fatal:
![Screenshot from 2021-07-14 09-08-40](https://user-images.githubusercontent.com/1194128/125636399-ea83416a-4f1f-49d1-94c5-5a8ce3734a7f.png)
Now we check for `http.ErrServerClosed` and return nil instead.
