### PR TITLE
adding option to set initial allocation via a command line

### DIFF
--- a/admin/main.go
+++ b/admin/main.go
@@ -92,7 +92,7 @@ func main() {
 			}
 		}()
 		network := getNetwork(netName, rpcUrl, testnet)
-		backendInstance, err = backend.NewBackend(ctx, mongoUrl, network.URL, dbName, nil, nil, logger, nil)
+		backendInstance, err = backend.NewBackend(ctx, mongoUrl, network.URL, dbName, nil, nil, nil, logger, nil)
 		if err != nil {
 			fatalExit(err)
 		}

--- a/grabber/main.go
+++ b/grabber/main.go
@@ -127,7 +127,7 @@ func main() {
 			// Ensure canonical form, since queries are case-sensitive.
 			lockedAccounts[i] = common.HexToAddress(l).Hex()
 		}
-		b, err := backend.NewBackend(ctx, mongoUrl, rpcUrl, dbName, lockedAccounts, nil, logger, nil)
+		b, err := backend.NewBackend(ctx, mongoUrl, rpcUrl, dbName, lockedAccounts, nil, nil, logger, nil)
 		if err != nil {
 			return fmt.Errorf("failed to create backend: %v", err)
 		}

--- a/server/backend/backend.go
+++ b/server/backend/backend.go
@@ -48,7 +48,7 @@ type Backend struct {
 	totalBurned     atomic.Value // *TotalBurned // Latest known. Eventually consistent.
 }
 
-func NewBackend(ctx context.Context, mongoUrl, rpcUrl, dbName string, lockedAccounts []string, signers map[common.Address]models.Signer,
+func NewBackend(ctx context.Context, mongoUrl, rpcUrl, dbName string, lockedAccounts []string, signers map[common.Address]models.Signer, initialAllocation *big.Int,
 	lgr *zap.Logger, cache *ristretto.Cache) (*Backend, error) {
 	rpcClient, err := rpc.DialHTTPWithClient(rpcUrl, &http.Client{Timeout: rpcClientTimeout})
 	if err != nil {
@@ -70,6 +70,7 @@ func NewBackend(ctx context.Context, mongoUrl, rpcUrl, dbName string, lockedAcco
 	b.dockerhubAPI = new(DockerHubAPI)
 	b.lockedAccounts = lockedAccounts
 	b.signers = signers
+	b.alloc.Store(initialAllocation)
 	b.Lgr = lgr
 
 	if cache == nil {

--- a/server/backend/backend_test.go
+++ b/server/backend/backend_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 package backend
@@ -19,7 +20,7 @@ import (
 
 func getBackend(t *testing.T) *Backend {
 	t.Helper()
-	b, err := NewBackend(context.Background(), "127.0.0.1:27017", "https://rpc.gochain.io", "testdb", nil, nil, zaptest.NewLogger(t), nil)
+	b, err := NewBackend(context.Background(), "127.0.0.1:27017", "https://rpc.gochain.io", "testdb", nil, nil, nil, zaptest.NewLogger(t), nil)
 	if err != nil {
 		t.Fatalf("failed to create backend: %v", err)
 	}


### PR DESCRIPTION
example of the command line

```
server -d ../front/dist/explorer/ -u https://testnet-rpc.gochain.io  -signers ../signers.json -locked-accounts 0x5610458Cf41EaBB850b9C0ed434cC3879beb3E2e:1431E0FAE6D7217CAA0000000 -locked-accounts 0xfa83B7876f28Ad60b795c3618fDB49f732c33dc4:1431E0FAE6D7217CAA0000000

```